### PR TITLE
skip poorly cropped images with zero size

### DIFF
--- a/TrackerAdaptation/adapt/crop_dataset.py
+++ b/TrackerAdaptation/adapt/crop_dataset.py
@@ -132,6 +132,10 @@ class CropDataset(Dataset):
 
         # Transform
         crop = rgb_to_srgb(crop)
+        h_, w_, _ = crop.shape
+        if h_ * w_ == 0:
+            return None
+        
         crop = self.transforms(crop.permute(2,0,1)) # HW3 to 3HW
 
         # Also crop and transform the semantic mask
@@ -177,6 +181,8 @@ class CropDataset(Dataset):
         return len(self.dataset)
     
     def collate(self, batch):
+        if None in batch:
+            return None
         batch_original = [item["original"] for item in batch]
         batch_crop = [item["crop"] for item in batch]
         return {

--- a/TrackerAdaptation/train.py
+++ b/TrackerAdaptation/train.py
@@ -106,6 +106,8 @@ def adapt_tracker(
         lmk_loss_per_view = dict()
 
         for views in dataloader_train:
+            if views is None:
+                continue
             if iteration >= last_iteration:
                 break
             iteration += 1


### PR DESCRIPTION
the solution is not very delicate, but it works
if the image has 0 sized dimension, the datset returns None instead of a dict
in train.py in the training cycle, if the batch has a zero sized image, the views object is None, so with continue we just skip the iteration